### PR TITLE
Remove date restriction on 'vaccinated over time' graph

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -143,7 +143,7 @@ function initializeLineCharts(csv) {
                 borderWidth: 2,
             }
         ],
-        true);
+        false);
     makeLineChart(
         "line-extrapolated",
         "Predicting England vaccinations",


### PR DESCRIPTION
I'm not aware of what the 2nd vaccination target but this will at least allow us to see current data.

Closes #6 